### PR TITLE
Improve error regexp

### DIFF
--- a/jai-mode.el
+++ b/jai-mode.el
@@ -207,7 +207,7 @@
 (add-to-list 'auto-mode-alist '("\\.jai\\'" . jai-mode))
 
 (defconst jai--error-regexp
-  "^\\([^ :]+\\):\\([0-9]+\\),\\([0-9]+\\):")
+  "^\\([^ \n:]+.*\.jai\\):\\([0-9]+\\),\\([0-9]+\\):")
 (push `(jai ,jai--error-regexp 1 2 3 2) compilation-error-regexp-alist-alist)
 (push 'jai compilation-error-regexp-alist)
 


### PR DESCRIPTION
This fixes two things:
1) A situation when a weird color ansi escape code makes hyperlinks after the very first error not work properly
2) Capturing everything up to .jai adds support for Windows, because it has a format of DISK:/actual/path/to/file.jai, and the previous regexp would stop at the colon after DISK