### PR TITLE
Dollar sign ($) doesn't quote characters in jai

### DIFF
--- a/jai-mode.el
+++ b/jai-mode.el
@@ -52,7 +52,6 @@
     (modify-syntax-entry ?|  "." table)
     (modify-syntax-entry ?^  "." table)
     (modify-syntax-entry ?!  "." table)
-    (modify-syntax-entry ?$  "/" table)
     (modify-syntax-entry ?=  "." table)
     (modify-syntax-entry ?<  "." table)
     (modify-syntax-entry ?>  "." table)


### PR DESCRIPTION
For example, this `$` in focus codebase (https://github.com/focus-editor/focus/blob/main/src/utils.jai#L276) makes the syntax highlighting go woozy. As far as I know, `$` in jai doesn't quote characters

![image](https://github.com/krig/jai-mode/assets/7038954/eb0ff68c-9c69-4c16-987b-20d0a1c7ab40)
