### PR TITLE
don't enfore compile message to start form the beginning of line

### DIFF
--- a/jai-mode.el
+++ b/jai-mode.el
@@ -225,7 +225,7 @@
 (add-to-list 'auto-mode-alist '("\\.jai\\'" . jai-mode))
 
 (defconst jai--error-regexp
-  "^\\([^ \n:]+.*\.jai\\):\\([0-9]+\\),\\([0-9]+\\):")
+  "\\([^ \n:]+.*\.jai\\):\\([0-9]+\\),\\([0-9]+\\):")
 (push `(jai ,jai--error-regexp 1 2 3 2) compilation-error-regexp-alist-alist)
 (push 'jai compilation-error-regexp-alist)
 


### PR DESCRIPTION
Some compiler reports list the file "indented" - e.g. not at the start of the line, and compilation-mode incorrectly parses them.